### PR TITLE
updated module import of store to match feature selector

### DIFF
--- a/libs/theme/src/lib/store/selectors/shell.selectors.ts
+++ b/libs/theme/src/lib/store/selectors/shell.selectors.ts
@@ -3,9 +3,9 @@ import { createFeatureSelector, createSelector } from '@ngrx/store';
 import { ShellState, ThemeState, initialThemeState } from '../reducers';
 
 // Selectors
-// export const getThemeState = createFeatureSelector<ThemeState>('theme');
+export const getThemeState = createFeatureSelector<ThemeState>('theme');
 
-export const getThemeState = state => <ThemeState>(state || initialThemeState);
+// export const getThemeState = state => <ThemeState>(state || initialThemeState);
 
 export const getShellState = createSelector(getThemeState, (state: ThemeState) => state.shell);
 

--- a/libs/theme/src/lib/theme.module.ts
+++ b/libs/theme/src/lib/theme.module.ts
@@ -22,7 +22,7 @@ import { ShellComponent } from './containers';
     SharedModule,
 
     // Vendor
-    StoreModule.forFeature('ThemeStore', themeReducer),
+    StoreModule.forFeature('theme', themeReducer),
     EffectsModule.forFeature([])
   ],
   declarations: [


### PR DESCRIPTION
When adding a store module the name has to match the one in the selector, in this case theme.

It's burned a couple people a few times.